### PR TITLE
respect DESTDIR during installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS =
 LDLIBS =
 INCLUDES = 
 
-prefix = /usr/local
+prefix = ${DESTDIR}/usr/local
 includedir = $(prefix)/include
 libdir = $(exec_prefix)/lib
 


### PR DESCRIPTION
Allow as usually installation of the files into a temporary location.